### PR TITLE
support ";\s*" separater and valuless keys

### DIFF
--- a/lib/URL/Encode/PP.pm
+++ b/lib/URL/Encode/PP.pm
@@ -74,9 +74,10 @@ sub url_params_each {
     utf8::downgrade($s, 1)
       or Carp::croak(q/Wide character in octet string/);
 
-    foreach my $pair (split /[&]/, $s) {
+    foreach my $pair (split /[&;] ?/, $s) {
         my ($k, $v) = split /=/, $pair, 2;
-        next unless defined $k && defined $v;
+        next unless defined $k;
+        $v = '' unless defined $v;
         for ($k, $v) {
             y/+/\x20/;
             s/%([0-9a-fA-F]{2})/$DecodeMap{$1}/gs;

--- a/t/020_params.t
+++ b/t/020_params.t
@@ -45,3 +45,24 @@ my $enc = 'foo=1&bar=2&bar=3';
     is($cnt, 3, 'url_params_each(): callback invoked three times');
 }
 
+
+{
+    my $enc = 'foo=1;bar=2;bar=3';
+    my $exp = [ foo => 1, bar => 2, bar => 3 ];
+    my $got = url_params_flat($enc);
+    is_deeply($got, $exp, 'url_params_flat()');
+}
+
+{
+    my $enc = 'foo=1& bar=2& bar=3';
+    my $exp = [ foo => 1, bar => 2, bar => 3 ];
+    my $got = url_params_flat($enc);
+    is_deeply($got, $exp, 'url_params_flat()');
+}
+
+{
+    my $enc = 'foo=1; bar=2& bar=3';
+    my $exp = [ foo => 1, bar => 2, bar => 3 ];
+    my $got = url_params_flat($enc);
+    is_deeply($got, $exp, 'url_params_flat()');
+}


### PR DESCRIPTION
Added suppoting ";" separator. W3C recommends that all web servers support `;` separators in addition to `&` separators. This p-r also supports space after separator, like this RT.
https://rt.cpan.org/Public/Bug/Display.html?id=31055

And I added valueless keys support. When `foo&bar=baz` is given, `foo` parameter is not accessible. Plack::Request support this.
