### PR TITLE
check version with VERSION method, not import

### DIFF
--- a/lib/URL/Encode.pm
+++ b/lib/URL/Encode.pm
@@ -20,7 +20,7 @@ BEGIN {
 
     if (!$use_pp) {
         eval { 
-            require URL::Encode::XS; URL::Encode::XS->import('0.03');
+            require URL::Encode::XS; URL::Encode::XS->VERSION('0.03');
         };
         $use_pp = !!$@;
     }


### PR DESCRIPTION
Trying to use import to check a version would sometimes check the version, but only if Exporter was being used. Otherwise, the version would throw an error or just be ignored. The correct way to check a version is using the VERSION method.